### PR TITLE
[WIP] added InjectHookVariableNames method

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -334,6 +334,7 @@ function createPanelIfReactLoaded() {
           extensionPanel.onHidden.addListener(panel => {
             // TODO: Stop highlighting and stuff.
           });
+          bridge.send('injectHookVariableNames', {shouldInject: true, sourceMap: 'some-sourcemap'});
         },
       );
 

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -202,6 +202,17 @@ function createPanelIfReactLoaded() {
           }
         };
 
+        const injectHookVariableNamesFunction = shouldInject => {
+          if (shouldInject) {
+            const sourceMap = '';
+            bridge.send('injectHookVariableNames', {shouldInject, sourceMap})
+
+            setTimeout(() => {
+              console.log('Loaded source maps.');
+            }, 100);
+          }
+        };
+
         root = createRoot(document.createElement('div'));
 
         render = (overrideTab = mostRecentOverrideTab) => {
@@ -220,6 +231,7 @@ function createPanelIfReactLoaded() {
               warnIfUnsupportedVersionDetected: true,
               viewAttributeSourceFunction,
               viewElementSourceFunction,
+              injectHookVariableNamesFunction,
             }),
           );
         };

--- a/packages/react-devtools-shared/src/backend/agent.js
+++ b/packages/react-devtools-shared/src/backend/agent.js
@@ -50,6 +50,11 @@ const debug = (methodName, ...args) => {
   }
 };
 
+type InjectHookVariableParams = {|
+  shouldInject: boolean,
+  sourceMap?: string,
+|};
+
 type ElementAndRendererID = {|
   id: number,
   rendererID: number,
@@ -196,6 +201,7 @@ export default class Agent extends EventEmitter<{|
     bridge.addListener('updateComponentFilters', this.updateComponentFilters);
     bridge.addListener('viewAttributeSource', this.viewAttributeSource);
     bridge.addListener('viewElementSource', this.viewElementSource);
+    bridge.addListener('injectHookVariableNames', this.injectHookVariableNames);
 
     // Temporarily support older standalone front-ends sending commands to newer embedded backends.
     // We do this because React Native embeds the React DevTools backend,
@@ -610,6 +616,14 @@ export default class Agent extends EventEmitter<{|
       console.warn(`Invalid renderer id "${rendererID}" for element "${id}"`);
     } else {
       renderer.prepareViewElementSource(id);
+    }
+  };
+
+  injectHookVariableNames = ({shouldInject, sourceMap}: InjectHookVariableParams) => {
+    if (!shouldInject) {
+      debug(`Hooks not found.`);
+    } else {
+      debug(JSON.stringify(sourceMap));
     }
   };
 

--- a/packages/react-devtools-shared/src/bridge.js
+++ b/packages/react-devtools-shared/src/bridge.js
@@ -20,6 +20,11 @@ import type {StyleAndLayout as StyleAndLayoutPayload} from 'react-devtools-share
 
 const BATCH_DURATION = 100;
 
+type InjectHookVariableParams = {|
+  shouldInject: boolean,
+  sourceMap?: string,
+|};
+
 type ElementAndRendererID = {|id: number, rendererID: RendererID|};
 
 type Message = {|
@@ -167,6 +172,7 @@ type FrontendEvents = {|
   updateConsolePatchSettings: [UpdateConsolePatchSettingsParams],
   viewAttributeSource: [ViewAttributeSourceParams],
   viewElementSource: [ElementAndRendererID],
+  injectHookVariableNames: [InjectHookVariableParams],
 
   // React Native style editor plug-in.
   NativeStyleEditor_measure: [ElementAndRendererID],

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -49,6 +49,10 @@ export type ViewAttributeSource = (
 export type CanViewElementSource = (
   inspectedElement: InspectedElement,
 ) => boolean;
+export type InjectHookVariableNames = (
+  shouldInject: boolean,
+  sourceMap?: string,
+) => void;
 
 export type Props = {|
   bridge: FrontendBridge,
@@ -62,6 +66,7 @@ export type Props = {|
   warnIfUnsupportedVersionDetected?: boolean,
   viewAttributeSourceFunction?: ?ViewAttributeSource,
   viewElementSourceFunction?: ?ViewElementSource,
+  injectHookVariableNamesFunction? : ?InjectHookVariableNames,
 
   // This property is used only by the web extension target.
   // The built-in tab UI is hidden in that case, in favor of the browser's own panel tabs.
@@ -106,6 +111,7 @@ export default function DevTools({
   warnIfUnsupportedVersionDetected = false,
   viewAttributeSourceFunction,
   viewElementSourceFunction,
+  injectHookVariableNamesFunction,
 }: Props) {
   const [currentTab, setTab] = useLocalStorage<TabID>(
     'React::DevTools::defaultTab',


### PR DESCRIPTION
fixes #72 

### Summary
A placeholder method `InjectHookVariableNames` defined in `main.js` and passed as props to `DevTools` component. This is supposed to wrap the functionality of loading source maps in the browser context and passing them to devtools

### Demo
<img width="575" alt="Screenshot 2020-10-30 at 12 35 33 AM" src="https://user-images.githubusercontent.com/29275810/97620840-19568480-1a48-11eb-999a-9036e861d93c.png">
