### PR TITLE
[WIP] load build and map files

### DIFF
--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -371,7 +371,25 @@ function checkPageForReact() {
   createPanelIfReactLoaded();
 }
 
+function loadBuildAndMapFiles(response) {
+  const staticJSFiles = response.filter((element) => element.url.includes('static/js'))
+  const staticMapFiles = Promise.all(staticJSFiles.map((file) => {
+    const url = `${file.url}.map`
+    return fetch(url)
+  }))
+  staticMapFiles.then((resolvedStaticMapFiles) => {
+    resolvedStaticMapFiles.map((file) => {
+      file.json().then((jsonContents) => {
+        console.log(file.url, jsonContents)
+      })
+    })
+  })
+}
+
 chrome.devtools.network.onNavigated.addListener(checkPageForReact);
+
+// Load build files and sourcemap
+chrome.devtools.inspectedWindow.getResources(loadBuildAndMapFiles);
 
 // Check to see if React has loaded once per second in case React is added
 // after page load


### PR DESCRIPTION
fixes #80 

### Summary
We want to load build files and sourcemap for the running app in the context of the browser extension, which is to be utilised for pinpointing coordinates for hook variable names in the future.

### Demo
<img width="627" alt="Screenshot 2020-10-30 at 12 42 44 AM" src="https://user-images.githubusercontent.com/29275810/97621982-a0f0c300-1a49-11eb-8323-5152b2862d64.png">
