### PR TITLE
[WIP]: Injecting parse function from extension to devtools

### DIFF
--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -317,17 +317,19 @@ const Dispatcher: DispatcherType = {
 
 // Inspect
 
+type HookSource = {
+  lineNumber: number | null,
+  columnNumber: number | null,
+  fileName: string | null,
+  functionName: string | null,
+}
 export type HooksNode = {
   id: number | null,
   isStateEditable: boolean,
   name: string,
   value: mixed,
   subHooks: Array<HooksNode>,
-  hookSource: {
-    lineNumber: number | null,
-    fileName: string | null,
-    functionName: string | null,
-  },
+  hookSource: HookSource,
   ...
 };
 export type HooksTree = Array<HooksNode>;
@@ -506,6 +508,7 @@ function buildTree(rootStack, readHookLog): HooksTree {
           subHooks: children,
           hookSource: {
             lineNumber: stack[j-1].lineNumber,
+            columnNumber: stack[j-1].columnNumber,
             functionName: stack[j-1].functionName,
             fileName: stack[j-1].fileName
           }
@@ -526,12 +529,13 @@ function buildTree(rootStack, readHookLog): HooksTree {
 
     // For the time being, only State and Reducer hooks support runtime overrides.
     const isStateEditable = primitive === 'Reducer' || primitive === 'State';
-    const hookSource = {lineNumber: null, functionName: null, fileName: null}
+    const hookSource: HookSource = {lineNumber: null, functionName: null, fileName: null, columnNumber: null}
     if (stack && stack.length === 1) {
       const stackFrame = stack[0]
       hookSource.lineNumber = stackFrame.lineNumber
       hookSource.functionName = stackFrame.functionName
       hookSource.fileName = stackFrame.fileName
+      hookSource.columnNumber = stackFrame.columnNumber
     }
 
     levelChildren.push({

--- a/packages/react-debug-tools/src/ReactDebugHooks.js
+++ b/packages/react-debug-tools/src/ReactDebugHooks.js
@@ -323,6 +323,11 @@ export type HooksNode = {
   name: string,
   value: mixed,
   subHooks: Array<HooksNode>,
+  hookSource: {
+    lineNumber: number | null,
+    fileName: string | null,
+    functionName: string | null,
+  },
   ...
 };
 export type HooksTree = Array<HooksNode>;
@@ -499,6 +504,11 @@ function buildTree(rootStack, readHookLog): HooksTree {
           name: parseCustomHookName(stack[j - 1].functionName),
           value: undefined,
           subHooks: children,
+          hookSource: {
+            lineNumber: stack[j-1].lineNumber,
+            functionName: stack[j-1].functionName,
+            fileName: stack[j-1].fileName
+          }
         });
         stackOfChildren.push(levelChildren);
         levelChildren = children;
@@ -516,6 +526,13 @@ function buildTree(rootStack, readHookLog): HooksTree {
 
     // For the time being, only State and Reducer hooks support runtime overrides.
     const isStateEditable = primitive === 'Reducer' || primitive === 'State';
+    const hookSource = {lineNumber: null, functionName: null, fileName: null}
+    if (stack && stack.length === 1) {
+      const stackFrame = stack[0]
+      hookSource.lineNumber = stackFrame.lineNumber
+      hookSource.functionName = stackFrame.functionName
+      hookSource.fileName = stackFrame.fileName
+    }
 
     levelChildren.push({
       id,
@@ -523,6 +540,7 @@ function buildTree(rootStack, readHookLog): HooksTree {
       name: primitive,
       value: hook.value,
       subHooks: [],
+      hookSource
     });
   }
 

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -203,8 +203,16 @@ function createPanelIfReactLoaded() {
         };
 
         function injectHookVariableNamesFunction(hookLog) {
-          console.log('injectHookVariableNamesFunction called with', hookLog)
-          return hookLog
+          const newHookLog = new Promise((resolve, reject) => {
+            setTimeout(() => {
+              const newHook = hookLog.map((hook) => {
+                return {...hook, 'variableName':'parsed-variable-name'}
+              })
+              resolve(newHook)
+            }, 8000)
+          })
+          console.log('injectHookVariableNamesFunction called with', newHookLog, hookLog)
+          return newHookLog
         }
 
         root = createRoot(document.createElement('div'));

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -202,15 +202,16 @@ function createPanelIfReactLoaded() {
           }
         };
 
-        function injectHookVariableNamesFunction(hookLog) {
+        function injectHookVariableNamesFunction(id, hookLog) {
+          // TODO Load source and source map, parse AST, mix in real names.
           const namedHookLogPromise = new Promise((resolve, reject) => {
             setTimeout(() => {
-              const newHookLog = hookLog.map((hook) => {
-                return {...hook, 'name':'hook-variable-name'}
-              })
-              resolve(newHookLog)
-            }, 2000)
-          })
+              const newHookLog = hookLog.map(hook => {
+                return {...hook, name: 'hook-variable-name'};
+              });
+              resolve(newHookLog);
+            }, 2000);
+          });
           return namedHookLogPromise;
         }
 
@@ -232,7 +233,7 @@ function createPanelIfReactLoaded() {
               warnIfUnsupportedVersionDetected: true,
               viewAttributeSourceFunction,
               viewElementSourceFunction,
-              injectHookVariableNamesFunction
+              injectHookVariableNamesFunction,
             }),
           );
         };

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -202,10 +202,9 @@ function createPanelIfReactLoaded() {
           }
         };
 
-        function injectHookVariableNamesFunction(hookLog, source) {
-          console.log('----main.js----')
-          console.log('injectHookVariableNamesFunction called with', hookLog, source)
-          return hookLog.map((log) => ({...log, name: 'State-alter'})) 
+        function injectHookVariableNamesFunction(hookLog) {
+          console.log('injectHookVariableNamesFunction called with', hookLog)
+          return hookLog
         }
 
         root = createRoot(document.createElement('div'));

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -203,16 +203,15 @@ function createPanelIfReactLoaded() {
         };
 
         function injectHookVariableNamesFunction(hookLog) {
-          const newHookLog = new Promise((resolve, reject) => {
+          const namedHookLogPromise = new Promise((resolve, reject) => {
             setTimeout(() => {
-              const newHook = hookLog.map((hook) => {
-                return {...hook, 'variableName':'parsed-variable-name'}
+              const newHookLog = hookLog.map((hook) => {
+                return {...hook, 'name':'hook-variable-name'}
               })
-              resolve(newHook)
-            }, 8000)
+              resolve(newHookLog)
+            }, 2000)
           })
-          console.log('injectHookVariableNamesFunction called with', newHookLog, hookLog)
-          return newHookLog
+          return namedHookLogPromise;
         }
 
         root = createRoot(document.createElement('div'));

--- a/packages/react-devtools-extensions/src/main.js
+++ b/packages/react-devtools-extensions/src/main.js
@@ -202,6 +202,12 @@ function createPanelIfReactLoaded() {
           }
         };
 
+        function injectHookVariableNamesFunction(hookLog, source) {
+          console.log('----main.js----')
+          console.log('injectHookVariableNamesFunction called with', hookLog, source)
+          return hookLog.map((log) => ({...log, name: 'State-alter'})) 
+        }
+
         root = createRoot(document.createElement('div'));
 
         render = (overrideTab = mostRecentOverrideTab) => {
@@ -220,6 +226,7 @@ function createPanelIfReactLoaded() {
               warnIfUnsupportedVersionDetected: true,
               viewAttributeSourceFunction,
               viewElementSourceFunction,
+              injectHookVariableNamesFunction
             }),
           );
         };

--- a/packages/react-devtools-shared/src/devtools/views/Components/InjectHookVariableNamesFunctionContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InjectHookVariableNamesFunctionContext.js
@@ -4,9 +4,12 @@ import {createContext} from 'react';
 import type {InjectHookVariableNamesFunction} from '../DevTools';
 
 export type Context = {|
-    injectHookVariableNamesFunction: InjectHookVariableNamesFunction | null,
-  |};
+  injectHookVariableNamesFunction: InjectHookVariableNamesFunction | null,
+|};
 
-const InjectHookVariableNamesFunctionContext = createContext<Context>(((null: any): Context));
-InjectHookVariableNamesFunctionContext.displayName = 'InjectHookVariableNamesFunctionContext';
+const InjectHookVariableNamesFunctionContext = createContext<Context>(
+  ((null: any): Context),
+);
+InjectHookVariableNamesFunctionContext.displayName =
+  'InjectHookVariableNamesFunctionContext';
 export default InjectHookVariableNamesFunctionContext;

--- a/packages/react-devtools-shared/src/devtools/views/Components/InjectHookVariableNamesFunctionContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InjectHookVariableNamesFunctionContext.js
@@ -1,0 +1,12 @@
+// @flow
+
+import {createContext} from 'react';
+import type {InjectHookVariableNamesFunction} from '../DevTools';
+
+export type Context = {|
+    injectHookVariableNamesFunction: InjectHookVariableNamesFunction | null,
+  |};
+
+const InjectHookVariableNamesFunctionContext = createContext<Context>(((null: any): Context));
+InjectHookVariableNamesFunctionContext.displayName = 'InjectHookVariableNamesFunctionContext';
+export default InjectHookVariableNamesFunctionContext;

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElement.js
@@ -52,6 +52,7 @@ export default function InspectedElementWrapper(_: Props) {
 
   const inspectedElement =
     inspectedElementID != null ? getInspectedElement(inspectedElementID) : null;
+  console.log('<InspectedElement> inspectedElement:', inspectedElement);
 
   const highlightElement = useCallback(() => {
     if (element !== null && inspectedElementID !== null) {

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -22,6 +22,7 @@ import {createResource} from '../../cache';
 import {BridgeContext, StoreContext} from '../context';
 import {hydrate, fillInPath} from 'react-devtools-shared/src/hydration';
 import {TreeStateContext} from './TreeContext';
+import InjectHookVariableNamesFunctionContext from './InjectHookVariableNamesFunctionContext';
 import {separateDisplayNameAndHOCs} from 'react-devtools-shared/src/utils';
 
 import type {
@@ -101,7 +102,7 @@ type Props = {|
 function InspectedElementContextController({children}: Props) {
   const bridge = useContext(BridgeContext);
   const store = useContext(StoreContext);
-
+  const injectHookVariableNamesFunction = useContext(InjectHookVariableNamesFunctionContext).injectHookVariableNamesFunction
   const storeAsGlobalCount = useRef(1);
 
   // Ask the backend to store the value at the specified path as a global variable.
@@ -254,7 +255,7 @@ function InspectedElementContextController({children}: Props) {
                     };
                   }),
             context: hydrateHelper(context),
-            hooks: hydrateHelper(hooks),
+            hooks: injectHookVariableNamesFunction ? injectHookVariableNamesFunction(hydrateHelper(hooks), source) :hydrateHelper(hooks),
             props: hydrateHelper(props),
             state: hydrateHelper(state),
           };

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -255,7 +255,7 @@ function InspectedElementContextController({children}: Props) {
                     };
                   }),
             context: hydrateHelper(context),
-            hooks: injectHookVariableNamesFunction ? injectHookVariableNamesFunction(hydrateHelper(hooks), source) :hydrateHelper(hooks),
+            hooks: injectHookVariableNamesFunction ? injectHookVariableNamesFunction(hydrateHelper(hooks)) :hydrateHelper(hooks),
             props: hydrateHelper(props),
             state: hydrateHelper(state),
           };

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -255,10 +255,19 @@ function InspectedElementContextController({children}: Props) {
                     };
                   }),
             context: hydrateHelper(context),
-            hooks: injectHookVariableNamesFunction ? injectHookVariableNamesFunction(hydrateHelper(hooks)) :hydrateHelper(hooks),
+            hooks: hydrateHelper(hooks),
             props: hydrateHelper(props),
             state: hydrateHelper(state),
           };
+
+          // If injectHookVariableNamesFunction prop present, wait on new hook (with variable names) to resolve
+          // and replace old hooks structure with the new one
+          if (injectHookVariableNamesFunction) {
+            const namedHooksPromise = injectHookVariableNamesFunction(hydrateHelper(hooks), source)
+            namedHooksPromise.then(namedHooks => {
+              inspectedElement.hooks = namedHooks
+            })
+          }
 
           element = store.getElementByID(id);
           if (element !== null) {

--- a/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
+++ b/packages/react-devtools-shared/src/devtools/views/Components/InspectedElementContext.js
@@ -263,7 +263,7 @@ function InspectedElementContextController({children}: Props) {
           // If injectHookVariableNamesFunction prop present, wait on new hook (with variable names) to resolve
           // and replace old hooks structure with the new one
           if (injectHookVariableNamesFunction) {
-            const namedHooksPromise = injectHookVariableNamesFunction(hydrateHelper(hooks), source)
+            const namedHooksPromise = injectHookVariableNamesFunction(hydrateHelper(hooks))
             namedHooksPromise.then(namedHooks => {
               inspectedElement.hooks = namedHooks
             })

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -36,8 +36,7 @@ import './root.css';
 
 import type {InspectedElement} from 'react-devtools-shared/src/devtools/views/Components/types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
-import type {Source} from '../../../../shared/ReactElementType'
-import type {Thenable} from '../cache'
+import type {Thenable} from '../cache';
 
 export type BrowserTheme = 'dark' | 'light';
 export type TabID = 'components' | 'profiler';
@@ -53,7 +52,10 @@ export type ViewElementSource = (
   id: number,
   inspectedElement: InspectedElement,
 ) => void;
-export type InjectHookVariableNamesFunction = (hookLog: HookLog) => Thenable<HookLog>;
+export type InjectHookVariableNamesFunction = (
+  id: number,
+  hookLog: HookLog,
+) => Thenable<HookLog>;
 export type ViewAttributeSource = (
   id: number,
   path: Array<string | number>,
@@ -120,7 +122,7 @@ export default function DevTools({
   warnIfUnsupportedVersionDetected = false,
   viewAttributeSourceFunction,
   viewElementSourceFunction,
-  injectHookVariableNamesFunction
+  injectHookVariableNamesFunction,
 }: Props) {
   const [currentTab, setTab] = useLocalStorage<TabID>(
     'React::DevTools::defaultTab',
@@ -135,10 +137,10 @@ export default function DevTools({
 
   const injectHookVariableNames = useMemo(
     () => ({
-      injectHookVariableNamesFunction: injectHookVariableNamesFunction || null
+      injectHookVariableNamesFunction: injectHookVariableNamesFunction || null,
     }),
-    [injectHookVariableNamesFunction]
-  )
+    [injectHookVariableNamesFunction],
+  );
 
   const viewElementSource = useMemo(
     () => ({
@@ -211,7 +213,8 @@ export default function DevTools({
               componentsPortalContainer={componentsPortalContainer}
               profilerPortalContainer={profilerPortalContainer}>
               <ViewElementSourceContext.Provider value={viewElementSource}>
-                <InjectHookVariableNamesFunctionContext.Provider value={injectHookVariableNames}>
+                <InjectHookVariableNamesFunctionContext.Provider
+                  value={injectHookVariableNames}>
                   <TreeContextController>
                     <ProfilerContextController>
                       <div className={styles.DevTools} ref={devToolsRef}>

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -53,7 +53,7 @@ export type ViewElementSource = (
   id: number,
   inspectedElement: InspectedElement,
 ) => void;
-export type InjectHookVariableNamesFunction = (hookLog: HookLog) => HookLog;
+export type InjectHookVariableNamesFunction = (hookLog: HookLog) => Promise<HookLog>;
 export type ViewAttributeSource = (
   id: number,
   path: Array<string | number>,

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -22,6 +22,7 @@ import TabBar from './TabBar';
 import {SettingsContextController} from './Settings/SettingsContext';
 import {TreeContextController} from './Components/TreeContext';
 import ViewElementSourceContext from './Components/ViewElementSourceContext';
+import InjectHookVariableNamesFunctionContext from './Components/InjectHookVariableNamesFunctionContext';
 import {ProfilerContextController} from './Profiler/ProfilerContext';
 import {ModalDialogContextController} from './ModalDialog';
 import ReactLogo from './ReactLogo';
@@ -35,13 +36,24 @@ import './root.css';
 
 import type {InspectedElement} from 'react-devtools-shared/src/devtools/views/Components/types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
+import type {Source} from '../../../../shared/ReactElementType'
 
 export type BrowserTheme = 'dark' | 'light';
 export type TabID = 'components' | 'profiler';
+type HookLogEntry = {
+  primitive: string,
+  stackError: Error,
+  value: mixed,
+  ...
+};
+
+type HookLog = Array<HookLogEntry> | null
+
 export type ViewElementSource = (
   id: number,
   inspectedElement: InspectedElement,
 ) => void;
+export type InjectHookVariableNamesFunction = (hookLog: HookLog, source: Source | null) => HookLog;
 export type ViewAttributeSource = (
   id: number,
   path: Array<string | number>,
@@ -62,6 +74,8 @@ export type Props = {|
   warnIfUnsupportedVersionDetected?: boolean,
   viewAttributeSourceFunction?: ?ViewAttributeSource,
   viewElementSourceFunction?: ?ViewElementSource,
+  // Passing HookVariableNamesFunction as a Prop
+  injectHookVariableNamesFunction?: ?InjectHookVariableNamesFunction,
 
   // This property is used only by the web extension target.
   // The built-in tab UI is hidden in that case, in favor of the browser's own panel tabs.
@@ -106,6 +120,7 @@ export default function DevTools({
   warnIfUnsupportedVersionDetected = false,
   viewAttributeSourceFunction,
   viewElementSourceFunction,
+  injectHookVariableNamesFunction
 }: Props) {
   const [currentTab, setTab] = useLocalStorage<TabID>(
     'React::DevTools::defaultTab',
@@ -117,6 +132,13 @@ export default function DevTools({
   if (overrideTab != null) {
     tab = overrideTab;
   }
+
+  const injectHookVariableNames = useMemo(
+    () => ({
+      injectHookVariableNamesFunction: injectHookVariableNamesFunction || null
+    }),
+    [injectHookVariableNamesFunction]
+  )
 
   const viewElementSource = useMemo(
     () => ({
@@ -179,7 +201,6 @@ export default function DevTools({
       }
     };
   }, [bridge]);
-
   return (
     <BridgeContext.Provider value={bridge}>
       <StoreContext.Provider value={store}>
@@ -190,40 +211,42 @@ export default function DevTools({
               componentsPortalContainer={componentsPortalContainer}
               profilerPortalContainer={profilerPortalContainer}>
               <ViewElementSourceContext.Provider value={viewElementSource}>
-                <TreeContextController>
-                  <ProfilerContextController>
-                    <div className={styles.DevTools} ref={devToolsRef}>
-                      {showTabBar && (
-                        <div className={styles.TabBar}>
-                          <ReactLogo />
-                          <span className={styles.DevToolsVersion}>
-                            {process.env.DEVTOOLS_VERSION}
-                          </span>
-                          <div className={styles.Spacer} />
-                          <TabBar
-                            currentTab={tab}
-                            id="DevTools"
-                            selectTab={setTab}
-                            tabs={tabs}
-                            type="navigation"
+                <InjectHookVariableNamesFunctionContext.Provider value={injectHookVariableNames}>
+                  <TreeContextController>
+                    <ProfilerContextController>
+                      <div className={styles.DevTools} ref={devToolsRef}>
+                        {showTabBar && (
+                          <div className={styles.TabBar}>
+                            <ReactLogo />
+                            <span className={styles.DevToolsVersion}>
+                              {process.env.DEVTOOLS_VERSION}
+                            </span>
+                            <div className={styles.Spacer} />
+                            <TabBar
+                              currentTab={tab}
+                              id="DevTools"
+                              selectTab={setTab}
+                              tabs={tabs}
+                              type="navigation"
+                            />
+                          </div>
+                        )}
+                        <div
+                          className={styles.TabContent}
+                          hidden={tab !== 'components'}>
+                          <Components
+                            portalContainer={componentsPortalContainer}
                           />
                         </div>
-                      )}
-                      <div
-                        className={styles.TabContent}
-                        hidden={tab !== 'components'}>
-                        <Components
-                          portalContainer={componentsPortalContainer}
-                        />
+                        <div
+                          className={styles.TabContent}
+                          hidden={tab !== 'profiler'}>
+                          <Profiler portalContainer={profilerPortalContainer} />
+                        </div>
                       </div>
-                      <div
-                        className={styles.TabContent}
-                        hidden={tab !== 'profiler'}>
-                        <Profiler portalContainer={profilerPortalContainer} />
-                      </div>
-                    </div>
-                  </ProfilerContextController>
-                </TreeContextController>
+                    </ProfilerContextController>
+                  </TreeContextController>
+                </InjectHookVariableNamesFunctionContext.Provider>
               </ViewElementSourceContext.Provider>
             </SettingsContextController>
             {warnIfLegacyBackendDetected && <WarnIfLegacyBackendDetected />}

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -53,7 +53,7 @@ export type ViewElementSource = (
   id: number,
   inspectedElement: InspectedElement,
 ) => void;
-export type InjectHookVariableNamesFunction = (hookLog: HookLog, source: Source | null) => HookLog;
+export type InjectHookVariableNamesFunction = (hookLog: HookLog) => HookLog;
 export type ViewAttributeSource = (
   id: number,
   path: Array<string | number>,

--- a/packages/react-devtools-shared/src/devtools/views/DevTools.js
+++ b/packages/react-devtools-shared/src/devtools/views/DevTools.js
@@ -37,6 +37,7 @@ import './root.css';
 import type {InspectedElement} from 'react-devtools-shared/src/devtools/views/Components/types';
 import type {FrontendBridge} from 'react-devtools-shared/src/bridge';
 import type {Source} from '../../../../shared/ReactElementType'
+import type {Thenable} from '../cache'
 
 export type BrowserTheme = 'dark' | 'light';
 export type TabID = 'components' | 'profiler';
@@ -46,14 +47,13 @@ type HookLogEntry = {
   value: mixed,
   ...
 };
-
-type HookLog = Array<HookLogEntry> | null
+export type HookLog = Array<HookLogEntry> | null;
 
 export type ViewElementSource = (
   id: number,
   inspectedElement: InspectedElement,
 ) => void;
-export type InjectHookVariableNamesFunction = (hookLog: HookLog) => Promise<HookLog>;
+export type InjectHookVariableNamesFunction = (hookLog: HookLog) => Thenable<HookLog>;
 export type ViewAttributeSource = (
   id: number,
   path: Array<string | number>,


### PR DESCRIPTION
*Requesting review for [this commit](https://github.com/MLH-Fellowship/react/commit/1c6d58fe0c3797f6ac39c1bdea4f4bd427154c85)*.

### How it's intended to work:
`injectHookVariableNamesFunction` returns a promise that resolves to the new hook object after 2 seconds (to mock for the potential delay in parsing) which gets passed down via context for rendering. As per the last discussion, the following happens:

1. A new resource type `hookResource` is declared (with the default `fetch` argument for `createResource` simply returning a promise that resolves to the initial hook object of the original `inspectedElement` object
2. If prop `injectHookVariableNamesFunction` is present, this function is called and the promise for new hooks obtained is written to the new hook resource
3. Inside the function `getInspectedElement` we read the hook resource to extract the new hooks objects and set it in the `inspectedElement` object


### How it's working:
We aren't able to handle promises properly along with the suspense and resource approach. Observations from looking in `cache.js`:
- For default cases (cases where we don't write anything to a resource) within `accessResult`, a `.then()` is called on a thenable and a pending status with the value as the thenable is returned
- For cases where we have already called `resource.write(key, val)` and object with resolved state and value as `val` is set and `accessResult` simply returns this object

In this approach, we're writing the promise of the new hook object as the value with the `inspectedElement` as the key in the `hookResource` and while reading from this resource, fulfilled promise object (containing the desired new hook object) is returned, instead of the actual object. However, if we don't write anything to the `hookResource` and trigger the default case (which returns the original hooks for now), things work as expected and hook array is returned on reading the resource. 
Screenshots of the `inspectedElement` for both these cases follow:

1. We write the promise of parsed names returned by `injectHookVariableNamesFunction` and then try to read It from the resource. This results in the hook key being a promise object.

<img width="624" alt="Screenshot 2020-11-10 at 2 21 48 AM" src="https://user-images.githubusercontent.com/29275810/98624692-5833e680-2334-11eb-856b-b17391bde61d.png">


2. We don't write the newly obtained promise which forces the default case while reading from `hookResource`, and it perfectly returns an array of hooks, set in `inspectedElement`

<img width="620" alt="Screenshot 2020-11-10 at 2 19 25 AM" src="https://user-images.githubusercontent.com/29275810/98624581-23c02a80-2334-11eb-9b74-4a8a5afebb76.png">

**Note:** The approach in the concerned commit works if we don't return a promise from `injectHookVariableNamesFunction`, instead just return a dummy hook object (for experimentation purposes) and write that to `hookResource`.

Maybe we're missing something really nuanced or something very basic? It feels like we have some degree of understanding of how suspense and `createResource` work, but there still are gaps in our knowledge and need nudging in the right direction